### PR TITLE
Fix Contact Us Section Links #71

### DIFF
--- a/index.html
+++ b/index.html
@@ -954,42 +954,48 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 			<div class="row d-flex contact-info mb-5">
 				<div class="col-md-6 col-lg-3 d-flex ftco-animate">
-					<div class="align-self-stretch box p-4 text-center">
-						<div class="icon d-flex align-items-center justify-content-center">
-							<span class="gradient-text icon-map-signs"></span>
-						</div>
-						<h3 class="mb-4">Address</h3>
-						<p><a href="#"> Mumbai, Maharashtra</a></p>
+					<div class="align-self-stretch box p-4 text-center"> 
+					  <a href="#" class="icon d-flex align-items-center justify-content-center">
+						<span class="gradient-text icon-map-signs"></span>
+					  </a>
+					  <a href="#"><h3 class="mb-4">Address</h3></a>
+				  	<p><a href="#">Mumbai, Maharashtra</a></p>
 					</div>
-				</div>
+				  </div>
+				   
 				<div class="col-md-6 col-lg-3 d-flex ftco-animate">
 					<div class="align-self-stretch box p-4 text-center">
-						<div class="icon d-flex align-items-center justify-content-center">
-							<span class="gradient-text"><i class="fab fa-youtube"></i></span>
-
-						</div>
-						<h3 class="mb-4">Youtube</h3>
-						<p><a href="https://www.youtube.com/channel/UCbUtPTIsWVP5AhbswlpKqww">IntelligenZ</a></p>
+					  <a href="https://www.youtube.com/channel/UCbUtPTIsWVP5AhbswlpKqww" target="_blank" class="icon d-flex align-items-center justify-content-center">
+						<span class="gradient-text">
+						  <i class="fab fa-youtube"></i>
+						</span>
+					  </a> 
+					  <a href="https://www.youtube.com/channel/UCbUtPTIsWVP5AhbswlpKqww" target="_blank"><h3 class="mb-4">YouTube</h3></a> 
+					  <p><a href="https://www.youtube.com/channel/UCbUtPTIsWVP5AhbswlpKqww" target="_blank">IntelligenZ</a></p>
 					</div>
-				</div>
-				<div class="col-md-6 col-lg-3 d-flex ftco-animate">
-					<div class="align-self-stretch box p-4 text-center">
-						<div class="icon d-flex align-items-center justify-content-center">
-							<span class="gradient-text icon-paper-plane"></span>
-						</div>
-						<h3 class="mb-4">Email Address</h3>
-						<p><a href="mailto: intelligenz0212@gmail.com"> intelligenz0212@gmail.com</a></p>
+				  </div>
+				  
+				  <div class="col-md-6 col-lg-3 d-flex ftco-animate">
+					<div class="align-self-stretch box p-4 text-center"> 
+					  <a href="mailto:intelligenz0212@gmail.com" class="icon d-flex align-items-center justify-content-center">
+						<span class="gradient-text icon-paper-plane"></span>
+					  </a> 
+					  <a href="mailto:intelligenz0212@gmail.com"><h3 class="mb-4">Email Address</h3></a> 
+					  <p><a href="mailto:intelligenz0212@gmail.com">intelligenz0212@gmail.com</a></p>
 					</div>
-				</div>
-				<div class="col-md-6 col-lg-3 d-flex ftco-animate">
-					<div class="align-self-stretch box p-4 text-center">
-						<div class="icon d-flex align-items-center justify-content-center">
-							<span class="gradient-text icon-globe"></span>
-						</div>
-						<h3 class="mb-4">Website</h3>
-						<p><a href="https://intelligenz.netlify.app/">intelligenz.netlify.app</a></p>
+				  </div>
+				  
+				  <div class="col-md-6 col-lg-3 d-flex ftco-animate">
+					<div class="align-self-stretch box p-4 text-center"> 
+					  <a href="https://intelligenz.netlify.app/" target="_blank" class="icon d-flex align-items-center justify-content-center">
+						<span class="gradient-text icon-globe"></span>
+					  </a>
+				   
+					  <a href="https://intelligenz.netlify.app/" target="_blank"><h3 class="mb-4">Website</h3></a>
+				  
+					  <p><a href="https://intelligenz.netlify.app/" target="_blank">intelligenz.netlify.app</a></p>
 					</div>
-				</div>
+				  </div> 
 			</div>
 			
 <!-- Button in Top Right Corner -->


### PR DESCRIPTION
This PR improves the Contact us section all socials by making the icon, heading, and address text all clickable, enhancing usability. Now users can click any of these elements to trigger the same link action, ensuring a consistent and accessible experience.

Fix Issues - #71 

![image](https://github.com/user-attachments/assets/b1da7277-f362-4b56-9260-3b654bc71d20)
